### PR TITLE
Fix FileProvider conflicts

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -74,6 +74,7 @@
         <source-file src="src/android/CameraLauncher.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/CordovaUri.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/FileHelper.java" target-dir="src/org/apache/cordova/camera" />
+        <source-file src="src/android/FileProvider.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/ExifHelper.java" target-dir="src/org/apache/cordova/camera" />
         <source-file src="src/android/xml/provider_paths.xml" target-dir="res/xml" />
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -61,7 +61,7 @@
         </config-file>
         <config-file target="AndroidManifest.xml" parent="application">
           <provider
-              android:name="androidx.core.content.FileProvider"
+              android:name="org.apache.cordova.camera.FileProvider"
               android:authorities="${applicationId}.provider"
               android:exported="false"
               android:grantUriPermissions="true" >

--- a/src/android/FileProvider.java
+++ b/src/android/FileProvider.java
@@ -1,0 +1,8 @@
+package org.apache.cordova.camera;
+
+/** 
+ * The class is only used in the manifest file and 
+ * avoids conflicts with other plugins that use FileProvider.
+ */
+public class FileProvider extends androidx.core.content.FileProvider {
+}


### PR DESCRIPTION
The build of a Tabris.js app that contains the 'tabris-plugin-camera' plugin fails due to the manifets merger exception. The exception occurs because of the FileProvider, which specified in the manifets file in both in the plugin and the 'tabris-android' platform. The same exception will be thrown again if another plugin also specifies the same provider.

The change creates a custom FileProvider, which just extends FileProvider and specifies in the manifest to avoid such conflicts.